### PR TITLE
Changed VLS_VGC_01 US gauge from CRIX_GCC_01 to CRIX_GCP_04

### DIFF
--- a/lcls-plc-crix-vac/PLC_CRIX_VAC/POUs/PRG_VLS_WINDOW.TcPOU
+++ b/lcls-plc-crix-vac/PLC_CRIX_VAC/POUs/PRG_VLS_WINDOW.TcPOU
@@ -107,7 +107,7 @@ VLS_ROUGH_GPI.M_SetBits(32767);
 VLS_ROUGH_GPI(PG=>);
 
 VLS_VGC_1(
-	i_stUSG:= CRIX_GCC_01.IG , 
+	i_stUSG:= CRIX_GCP_04.PG , 
 	i_stDSG:= VLS_GCC_01.IG , 
 	i_xDis_DPIlk:= FALSE , 
 	i_xPMPS_OK:= TRUE , 


### PR DESCRIPTION
Upstream gauge for VLS:VGC:01 was changed from CRIX:GCC:01 to the CRIX:GCP:04 combo gauge