### PR TITLE
Changed LCLS General Version

### DIFF
--- a/lcls-plc-crix-vac/PLC_CRIX_VAC/PLC_CRIX_VAC.plcproj
+++ b/lcls-plc-crix-vac/PLC_CRIX_VAC/PLC_CRIX_VAC.plcproj
@@ -174,7 +174,7 @@
   </ItemGroup>
   <ItemGroup>
     <PlaceholderResolution Include="LCLS General">
-      <Resolution>LCLS General, 2.4.2 (SLAC)</Resolution>
+      <Resolution>LCLS General, 2.6.0 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="LCLS Vacuum">
       <Resolution>LCLS Vacuum, 2.1.0 (SLAC - LCLS)</Resolution>


### PR DESCRIPTION
Changed LCLS General Libary version to fix VGC valve 06 error spamming issue.
(Didn't change LCLS Vacuum Library version, ignore the branch name)